### PR TITLE
Fix conflicting return type

### DIFF
--- a/makeblock/src/MeInfraredReceiver.h
+++ b/makeblock/src/MeInfraredReceiver.h
@@ -157,7 +157,7 @@ public:
  * \par Others
  *   None
  */
-  int16_t read(void);
+  int read();
 
 /**
  * \par Function

--- a/makeblock/src/MeSerial.h
+++ b/makeblock/src/MeSerial.h
@@ -158,7 +158,7 @@ public:
  * \par Others
  *   None
  */
-  int16_t read(void);
+  int read();
 
 /**
  * \par Function
@@ -174,7 +174,7 @@ public:
  * \par Others
  *   None
  */
-  int16_t available(void);
+  int available();
 
 /**
  * \par Function


### PR DESCRIPTION
Conflicting return type specified for 'virtual int16_t MeSerial::read()' and 'virtual int16_t MeSerial::available()'
It should be the same as defined in SoftwareSerial/SoftwareSerial.h