### PR TITLE
fix MegaPiFirmware RGB id

### DIFF
--- a/examples/Firmware_for_MegaPi/Firmware_for_MegaPi.ino
+++ b/examples/Firmware_for_MegaPi/Firmware_for_MegaPi.ino
@@ -184,7 +184,7 @@ float RELAX_ANGLE = -1;                    //Natural balance angle,should be adj
 #define JOYSTICK               5
 #define GYRO                   6
 #define SOUND_SENSOR           7
-#define RGBLED                 8
+#define RGBLED                 18
 #define SEVSEG                 9
 #define MOTOR                  10
 #define SERVO                  11


### PR DESCRIPTION
Due to issue described here:
https://github.com/Makeblock-official/Makeblock-Libraries/issues/42