### PR TITLE
Warning fixes & const-correctness

### DIFF
--- a/src/MeCompass.cpp
+++ b/src/MeCompass.cpp
@@ -782,7 +782,6 @@ void MeCompass::read_EEPROM_Buffer(void)
 void MeCompass::write_EEPROM_Buffer(struct Compass_Calibration_Parameter *parameter_pointer)
 {
   uint8_t *buffer_pointer;
-  uint8_t verify_number;  
   parameter_pointer -> verify_flag = (uint8_t)( parameter_pointer -> X_excursion
                                               + parameter_pointer -> Y_excursion
                                               + parameter_pointer -> Z_excursion

--- a/src/MeEncoderOnBoard.cpp
+++ b/src/MeEncoderOnBoard.cpp
@@ -227,7 +227,7 @@ void MeEncoderOnBoard::reset(uint8_t slot)
  * \par Others
  *   None
  */
-uint8_t MeEncoderOnBoard::getSlotNum(void)
+uint8_t MeEncoderOnBoard::getSlotNum(void) const
 {
   return _Slot;
 }
@@ -246,7 +246,7 @@ uint8_t MeEncoderOnBoard::getSlotNum(void)
  * \par Others
  *   None
  */
-uint8_t MeEncoderOnBoard::getIntNum(void)
+uint8_t MeEncoderOnBoard::getIntNum(void) const
 {
   return _IntNum;
 }
@@ -265,7 +265,7 @@ uint8_t MeEncoderOnBoard::getIntNum(void)
  * \par Others
  *   None
  */
-uint8_t MeEncoderOnBoard::getPortA(void)
+uint8_t MeEncoderOnBoard::getPortA(void) const
 {
   return _Port_A;
 }
@@ -284,7 +284,7 @@ uint8_t MeEncoderOnBoard::getPortA(void)
  * \par Others
  *   None
  */
-uint8_t MeEncoderOnBoard::getPortB(void)
+uint8_t MeEncoderOnBoard::getPortB(void) const
 {
   return _Port_B;
 }
@@ -303,7 +303,7 @@ uint8_t MeEncoderOnBoard::getPortB(void)
  * \par Others
  *   None
  */
-long MeEncoderOnBoard::getPulsePos(void)
+long MeEncoderOnBoard::getPulsePos(void) const
 {
   return encode_structure.pulsePos;
 }
@@ -399,7 +399,7 @@ void MeEncoderOnBoard::setCurrentSpeed(float speed)
  * \par Others
  *   None
  */
-float MeEncoderOnBoard::getCurrentSpeed(void)
+float MeEncoderOnBoard::getCurrentSpeed(void) const
 {
   return encode_structure.currentSpeed;
 }
@@ -418,7 +418,7 @@ float MeEncoderOnBoard::getCurrentSpeed(void)
  * \par Others
  *   None
  */
-int16_t MeEncoderOnBoard::getCurPwm(void)
+int16_t MeEncoderOnBoard::getCurPwm(void) const
 {
   return encode_structure.currentPwm;
 }
@@ -545,7 +545,7 @@ void MeEncoderOnBoard::updateCurPos(void)
  * \par Others
  *    None
  */
-long MeEncoderOnBoard::getCurPos(void)
+long MeEncoderOnBoard::getCurPos(void) const
 {
   return encode_structure.currentPos;
 }
@@ -675,7 +675,7 @@ void MeEncoderOnBoard::moveTo(long position,float speed,int16_t extId,cb callbac
  * \par Others
  *    None
  */
-long MeEncoderOnBoard::distanceToGo(void)
+long MeEncoderOnBoard::distanceToGo(void) const
 {
   return encode_structure.targetPos - encode_structure.currentPos;
 }
@@ -803,9 +803,7 @@ void MeEncoderOnBoard::setMotionMode(int16_t motionMode)
  */
 int16_t MeEncoderOnBoard::pidPositionToPwm(void)
 {
-  float cur_pos = 0;
   float seek_speed = 0;
-  float seek_temp = 0;
   float pos_error = 0;
   float speed_error = 0;
   float d_component = 0;
@@ -1032,7 +1030,7 @@ void MeEncoderOnBoard::pwmMove(void)
  * \par Others
  *    None
  */
-boolean MeEncoderOnBoard::isTarPosReached(void)
+boolean MeEncoderOnBoard::isTarPosReached(void) const
 {
   return _Lock_flag;
 }

--- a/src/MeEncoderOnBoard.h
+++ b/src/MeEncoderOnBoard.h
@@ -183,7 +183,7 @@ public:
  * \par Others
  *   None
  */
-  uint8_t getSlotNum(void);
+  uint8_t getSlotNum(void) const;
 
 /**
  * \par Function
@@ -199,7 +199,7 @@ public:
  * \par Others
  *   None
  */
-  uint8_t getIntNum(void);
+  uint8_t getIntNum(void) const;
   
 /**
  * \par Function
@@ -215,7 +215,7 @@ public:
  * \par Others
  *   None
  */
-  uint8_t getPortA(void);
+  uint8_t getPortA(void) const;
 
 /**
  * \par Function
@@ -231,7 +231,7 @@ public:
  * \par Others
  *   None
  */
-  uint8_t getPortB(void);
+  uint8_t getPortB(void) const;
 
 /**
  * \par Function
@@ -247,7 +247,7 @@ public:
  * \par Others
  *   None
  */
-  long getPulsePos(void);
+  long getPulsePos(void) const;
 
 /**
  * \par Function
@@ -328,7 +328,7 @@ public:
  * \par Others
  *   None
  */
-  float getCurrentSpeed(void);
+  float getCurrentSpeed(void) const;
 
 /**
  * \par Function
@@ -344,7 +344,7 @@ public:
  * \par Others
  *   None
  */
-  int16_t getCurPwm(void);
+  int16_t getCurPwm(void) const;
 
 /**
  * \par Function
@@ -424,7 +424,7 @@ public:
  * \par Others
  *    None
  */
-  long getCurPos(void);
+  long getCurPos(void) const;
 
 /**
  * \par Function
@@ -518,7 +518,7 @@ public:
  * \par Others
  *    None
  */
-  long distanceToGo();
+  long distanceToGo() const;
 
 /**
  * \par Function
@@ -687,7 +687,7 @@ public:
  * \par Others
  *    None
  */
-  boolean isTarPosReached(void);
+  boolean isTarPosReached(void) const;
 
 /**
  * \par Function

--- a/src/MeGyro.cpp
+++ b/src/MeGyro.cpp
@@ -216,7 +216,7 @@ void MeGyro::update(void)
     return;
   }
 
-  double ax, ay, az;
+  double ax, ay;
   /* assemble 16 bit sensor data */
   accX = ( (i2cData[0] << 8) | i2cData[1] );
   accY = ( (i2cData[2] << 8) | i2cData[3] );
@@ -277,7 +277,7 @@ void MeGyro::fast_update(void)
 {
   static unsigned long	last_time = 0;
   int8_t return_value;
-  double dt, filter_coefficient;
+  double dt;
 
   dt = (double)(millis() - last_time) / 1000.0;
   last_time = millis();
@@ -289,7 +289,7 @@ void MeGyro::fast_update(void)
     return;
   }
 
-  double ax, ay, az;
+  double ax, ay;
   /* assemble 16 bit sensor data */
   accX = ( (i2cData[0] << 8) | i2cData[1] );
   accY = ( (i2cData[2] << 8) | i2cData[3] );
@@ -336,7 +336,7 @@ void MeGyro::fast_update(void)
  * \par Others
  *   None
  */
-uint8_t MeGyro::getDevAddr(void)
+uint8_t MeGyro::getDevAddr(void) const
 {
   return Device_Address;
 }
@@ -355,7 +355,7 @@ uint8_t MeGyro::getDevAddr(void)
  * \par Others
  *   X-axis angle value is calculated by complementary filter.
  */
-double MeGyro::getAngleX(void)
+double MeGyro::getAngleX(void) const
 {
   return gx;
 }
@@ -374,7 +374,7 @@ double MeGyro::getAngleX(void)
  * \par Others
  *   Y-axis angle value is calculated by complementary filter.
  */
-double MeGyro::getAngleY(void)
+double MeGyro::getAngleY(void) const
 {
   return gy;
 }
@@ -393,7 +393,7 @@ double MeGyro::getAngleY(void)
  * \par Others
  *   Z-axis angle value is integral of Z-axis angular velocity.
  */
-double MeGyro::getAngleZ(void)
+double MeGyro::getAngleZ(void) const
 {
   return gz;
 }
@@ -412,7 +412,7 @@ double MeGyro::getAngleZ(void)
  * \par Others
  *   None
  */
-double MeGyro::getGyroX(void)
+double MeGyro::getGyroX(void) const
 {
   return gyrX;
 }
@@ -431,7 +431,7 @@ double MeGyro::getGyroX(void)
  * \par Others
  *   None
  */
-double MeGyro::getGyroY(void)
+double MeGyro::getGyroY(void) const
 {
   return gyrY;
 }
@@ -450,7 +450,7 @@ double MeGyro::getGyroY(void)
  * \par Others
  *   Z-axis angle value is integral of Z-axis angular velocity.
  */
-double MeGyro::getAngle(uint8_t index)
+double MeGyro::getAngle(uint8_t index) const
 {
   if(index == 1)
   {

--- a/src/MeGyro.h
+++ b/src/MeGyro.h
@@ -209,7 +209,7 @@ public:
  * \par Others
  *   None
  */
-  uint8_t getDevAddr(void);
+  uint8_t getDevAddr(void) const;
 
 /**
  * \par Function
@@ -225,7 +225,7 @@ public:
  * \par Others
  *   X-axis angle value is calculated by complementary filter.
  */
-  double getAngleX(void);
+  double getAngleX(void) const;
 
 /**
  * \par Function
@@ -241,7 +241,7 @@ public:
  * \par Others
  *   Y-axis angle value is calculated by complementary filter.
  */
-  double getAngleY(void);
+  double getAngleY(void) const;
 
 /**
  * \par Function
@@ -257,7 +257,7 @@ public:
  * \par Others
  *   Z-axis angle value is integral of Z-axis angular velocity.
  */
-  double getAngleZ(void);
+  double getAngleZ(void) const;
 
 /**
  * \par Function
@@ -273,7 +273,7 @@ public:
  * \par Others
  *   None
  */
-  double getGyroX(void);
+  double getGyroX(void) const;
 
 /**
  * \par Function
@@ -289,7 +289,7 @@ public:
  * \par Others
  *   None
  */
-  double getGyroY(void);
+  double getGyroY(void) const;
 
 /**
  * \par Function
@@ -305,7 +305,7 @@ public:
  * \par Others
  *   Z-axis angle value is integral of Z-axis angular velocity.
  */
-  double getAngle(uint8_t index);
+  double getAngle(uint8_t index) const;
 
 private:
   volatile uint8_t  _AD0;

--- a/src/MeInfraredReceiver.cpp
+++ b/src/MeInfraredReceiver.cpp
@@ -121,10 +121,9 @@ void MeInfraredReceiver::begin(void)
  * \par Others
  *   None
  */
-int16_t MeInfraredReceiver::read(void)
+int MeInfraredReceiver::read(void)
 {
   int16_t val;
-  uint16_t i;
   val = MeSerial::read();     /* Read serial infrared data */
   val &= 0xff;
   return(val);

--- a/src/MeMegaPi.h
+++ b/src/MeMegaPi.h
@@ -109,8 +109,8 @@ Encoder_port_type encoder_Port[6] =
 
 megapi_dc_type megapi_dc_Port[14] =
 {
-  { NC, NC }, {33,32,11}, {40,41, 7}, {47,48, 6}, {A3,A2, 4},
-  { NC, NC }, { NC, NC }, { NC, NC }, { NC, NC }, {35,34,12},
+  {NC,NC,NC}, {33,32,11}, {40,41, 7}, {47,48, 6}, {A3,A2, 4},
+  {NC,NC,NC}, {NC,NC,NC}, {NC,NC,NC}, {NC,NC,NC}, {35,34,12},
   {36,37, 8}, {42,43, 9}, {A5,A4, 5},
 };
 

--- a/src/MePm25Sensor.cpp
+++ b/src/MePm25Sensor.cpp
@@ -531,7 +531,7 @@ MePm25Sensor::MePm25Sensor(uint8_t receivePin, uint8_t transmitPin, bool inverse
      {
         // get the new byte:
          inputData = read();
-        if(rxflag & 0x80 == 0x80) 
+        if((rxflag & 0x80) == 0x80) 
         {
              //normal data byte - add to buffer
             cnt++;
@@ -648,7 +648,7 @@ MePm25Sensor::MePm25Sensor(uint8_t receivePin, uint8_t transmitPin, bool inverse
     {
         // get the new byte:
          inputData = read();
-        if(parsingSysex & 0x81 == 0x81) 
+        if((parsingSysex & 0x81) == 0x81) 
         {
              //normal data byte - add to buffer
             rxbuf.storedInputData[sysexBytesRead] = inputData;

--- a/src/MeSmartServo.cpp
+++ b/src/MeSmartServo.cpp
@@ -1077,7 +1077,6 @@ void MeSmartServo::assignDevIdResponse(void *arg)
  */
 void MeSmartServo::processSysexMessage(void)
 {
-  uint8_t i;
   if(sysex.val.dev_id != ALL_DEVICE)
   {
     switch(sysex.val.srv_id)

--- a/src/MeTemperature.cpp
+++ b/src/MeTemperature.cpp
@@ -170,10 +170,7 @@ float MeTemperature::temperature(void)
 {
   byte  i;
   byte  present = 0;
-  byte  type_s;
   byte  data[12];
-  byte	addr[8];
-  float celsius;
   long  time;
 
   _ts.reset();

--- a/src/MeVoice.cpp
+++ b/src/MeVoice.cpp
@@ -128,7 +128,6 @@ void MeVoice::begin(long speed)
 int16_t MeVoice::read(void)
 {
   int16_t val;
-  uint16_t i;
   val = MeSerial::read();     /* Read serial infrared data */
   val &= 0xff;
   return(val);

--- a/src/utility/EEPROM.h
+++ b/src/utility/EEPROM.h
@@ -40,7 +40,7 @@ struct EERef{
     
     //Access/read members.
     uint8_t operator*() const            { return eeprom_read_byte( (uint8_t*) index ); }
-    operator const uint8_t() const       { return **this; }
+    operator uint8_t() const             { return **this; }
     
     //Assignment/write members.
     EERef &operator=( const EERef &ref ) { return *this = *ref; }
@@ -89,7 +89,7 @@ struct EEPtr{
     EEPtr( const int index )
         : index( index )                {}
         
-    operator const int() const          { return index; }
+    operator int() const                { return index; }
     EEPtr &operator=( int in )          { return index = in, *this; }
     
     //Iterator functionality.

--- a/src/utility/EEPROM.h
+++ b/src/utility/EEPROM.h
@@ -142,5 +142,6 @@ struct EEPROMClass{
     }
 };
 
+__attribute__((unused))
 static EEPROMClass EEPROM;
 #endif


### PR DESCRIPTION
* I have fixed some (but far from all) compiler warnings encountered when using this library with PlatformIO.
* I have also added missing const-declarations for getter functions in the MeEncoderOnBoard & MeGyro classes. This should really be done for all classes, but I only needed these for the project I'm working on at the moment.