### PR TITLE
Update library version tag

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=MakeBlockDrive
-version=3.24
+version=3.26
 author=Mark Yan, Makeblock
 maintainer=MakeBlock <www.makeblock.cc>
 sentence= Use to drive all devices provided by Makeblock company.


### PR DESCRIPTION
Current listed version is wrong... it is now 3.26, not 3.24 ;) This also means the platformio library manager doesn't know about the last two updates. 