### PR TITLE
fix return type of check MeSuperVariable::set_variable

### DIFF
--- a/src/MeSuperVariable.cpp
+++ b/src/MeSuperVariable.cpp
@@ -221,7 +221,7 @@ void MeSuperVariable::arduino_super_var(uint8_t *data, uint32_t len, uint8_t *ou
  * \par Others
  *    None
  */
-void * MeSuperVariable::set_variable(char *name, uint8_t type, void *data, uint8_t len)//设置变量的值，要指定数据类型
+bool MeSuperVariable::set_variable(char *name, uint8_t type, void *data, uint8_t len)//设置变量的值，要指定数据类型
 {
   bool ret;
   bool bool_val,*bool_p;

--- a/src/MeSuperVariable.h
+++ b/src/MeSuperVariable.h
@@ -301,7 +301,7 @@ public:
    * \par Others
    *    None
    */
-  void *set_variable(char *name,uint8_t type,void *data, uint8_t len);
+  bool set_variable(char *name,uint8_t type,void *data, uint8_t len);
   
   /**
    * \par Function


### PR DESCRIPTION
This fixes the following compilation error:

```
/home/sur/Arduino/libraries/makeblock/src/MeSuperVariable.cpp: In member function 'void* MeSuperVariable::set_variable(char*, uint8_t, void*, uint8_t)':
/home/sur/Arduino/libraries/makeblock/src/MeSuperVariable.cpp:241:14: error: cannot convert 'bool' to 'void*' in return
       return false;
              ^~~~~
```