### PR TITLE
Fix for Multiple Definition Error for MeMegaPi

### DIFF
--- a/src/MeMegaPi.cpp
+++ b/src/MeMegaPi.cpp
@@ -1,0 +1,36 @@
+#include "MeMegaPi.h"
+
+MePort_Sig mePort[17] =
+{
+   { NC, NC }, {  NC,  NC }, {  NC,  NC }, {  NC,  NC }, {  NC,  NC }, 
+   { 16, 17 }, {  A8,  A9 }, { A10, A11 }, { A13, A12 }, {  NC,  NC }, 
+   { NC, NC }, {  NC,  NC }, {  NC,  NC }, {  NC,  NC }, {  NC,  NC },
+   { NC, NC },{ NC, NC },
+};
+
+Encoder_port_type encoder_Port[6] =
+{
+  { NC,     NC,     NC,     NC,     NC},
+  //NET2    NET1    PWM     DIR1    DIR2
+  { 18,     31,     12,     34,     35},
+  //ENB A   ENB B   PWMB    DIR B1  DIR B2
+  { 19,     38,     8,      37,     36},
+  { 3,      49,     9,      43,     42},
+  { 2,      A1,     5,      A4,     A5},
+  { NC,     NC,     NC,     NC,     NC},
+};
+
+megapi_dc_type megapi_dc_Port[14] =
+{
+  {NC,NC,NC}, {33,32,11}, {40,41, 7}, {47,48, 6}, {A3,A2, 4},
+  {NC,NC,NC}, {NC,NC,NC}, {NC,NC,NC}, {NC,NC,NC}, {35,34,12},
+  {36,37, 8}, {42,43, 9}, {A5,A4, 5},
+};
+
+megaPi_slot_type megaPi_slots[4] =
+{
+  {35,   34,   33,   32,   31,  18,  12,   11},
+  {36,   37,   40,   41,   38,  19,   8,   7},
+  {42,   43,   47,   48,   49,   3,   9,   6},
+  {A5,   A4,   A3,   A2,   A1,   2,   5,   4},    // for megapi
+};

--- a/src/MeMegaPi.h
+++ b/src/MeMegaPi.h
@@ -87,39 +87,13 @@
 #define PORT4A  PORT_4
 #define PORT4B  PORT_12
 
- MePort_Sig mePort[17] =
- {
-   { NC, NC }, {  NC,  NC }, {  NC,  NC }, {  NC,  NC }, {  NC,  NC }, 
-   { 16, 17 }, {  A8,  A9 }, { A10, A11 }, { A13, A12 }, {  NC,  NC }, 
-   { NC, NC }, {  NC,  NC }, {  NC,  NC }, {  NC,  NC }, {  NC,  NC },
-   { NC, NC },{ NC, NC },
- };
+extern MePort_Sig mePort[17];
 
-Encoder_port_type encoder_Port[6] =
-{
-  { NC,     NC,     NC,     NC,     NC},
-  //NET2    NET1    PWM     DIR1    DIR2
-  { 18,     31,     12,     34,     35},
-  //ENB A   ENB B   PWMB    DIR B1  DIR B2
-  { 19,     38,     8,      37,     36},
-  { 3,      49,     9,      43,     42},
-  { 2,      A1,     5,      A4,     A5},
-  { NC,     NC,     NC,     NC,     NC},
-};
+extern Encoder_port_type encoder_Port[6];
 
-megapi_dc_type megapi_dc_Port[14] =
-{
-  {NC,NC,NC}, {33,32,11}, {40,41, 7}, {47,48, 6}, {A3,A2, 4},
-  {NC,NC,NC}, {NC,NC,NC}, {NC,NC,NC}, {NC,NC,NC}, {35,34,12},
-  {36,37, 8}, {42,43, 9}, {A5,A4, 5},
-};
+extern megapi_dc_type megapi_dc_Port[14];
 
-megaPi_slot_type megaPi_slots[4] =
-{
-  {35,   34,   33,   32,   31,  18,  12,   11},
-  {36,   37,   40,   41,   38,  19,   8,   7},
-  {42,   43,   47,   48,   49,   3,   9,   6},
-  {A5,   A4,   A3,   A2,   A1,   2,   5,   4},    // for megapi
-};
+extern megaPi_slot_type megaPi_slots[4];
+
 //for step motor on board
 #endif // MeMegaPi_H


### PR DESCRIPTION
Having multiple code files that include "MeMegaPi.h" causes a Multiple Definitions error.

Steps to Reproduce :

create a new Header file, example : "TestHeader.h"
in TestHeader.h add #include "MeMegaPi.h"
in your main .INO file #include "TestHeader.h"
Cause :
The MeMegaPi.h file contains variable definitions instead of declarations, leading to multiple definitions when included in multiple compilation units.

Solution:
We moved the variable definitions from MeMegaPi.h to MeMegaPi.cpp and declared them as extern in MeMegaPi.h. This change ensures the variables are only defined once, resolving the multiple definition errors.